### PR TITLE
Allow dots in params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,8 @@ Layout/ParameterAlignment:
   - with_fixed_indentation
 Metrics/BlockLength:
   Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
 Style/ClassAndModuleChildren:
   Description: Checks style of children classes and modules.
   Enabled: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   scope path: '/api' do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
-      resources :users, only: [:index, :show, :create]
+      resources :users, only: [:index, :create]
+      get 'users/:id', to: 'users#show', constraints: { id: /[^\/?]+/ }
       resources :payment_intents, only: [:create]
       post 'fintoc/:id/webhook', to: 'fintoc#webhook'
       post 'session', to: 'session#create'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgresql:
     image: postgres:11.3
     ports:
-    - 5432
+    - 5432:5432
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ''
@@ -13,9 +13,9 @@ services:
   redis:
     image: redis
     ports:
-    - 6379
+    - 6379:6379
     volumes:
     - redis_data:/data
 volumes:
-  postgresql_data: 
-  redis_data: 
+  postgresql_data:
+  redis_data:


### PR DESCRIPTION
The default regex matcher for path segments used by Rails doesn't allow dots (the exact matcher is this one: `/[^\/.?]+/`). I changed it so accounts with dots correctly get their users: `/[^\/?]+/`